### PR TITLE
Bundle partitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,10 @@
     "python.formatting.provider": "black",
     "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": true,
     },
     "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
     },
     "editor.rulers": [120]

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -10,12 +10,15 @@ import fsspec
 import lz4
 import numpy as np
 import utm
+from joblib import Memory
 from PIL import Image
 
 from pit30m.camera import CamName
 from pit30m.data.partitions import Partition
 from pit30m.data.submap import Map
 from pit30m.time_utils import gps_seconds_to_utc
+
+memory = Memory(location=os.path.expanduser("~/.cache/pit30m"), verbose=0)
 
 
 @dataclass
@@ -106,6 +109,7 @@ class LogReader:
         return combined_indices
 
     @property
+    @memory.cache(verbose=0)
     def partition_assigments(self):
         """Fetches partition indices from S3 and converts them to boolean arrays according to the reader partition values"""
 

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -1,9 +1,8 @@
 import io
 import os
 from dataclasses import dataclass
-from enum import Enum
 from functools import cached_property, lru_cache
-from typing import Any, Dict, Iterator, Optional, Set
+from typing import Iterator, Optional, Set
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -60,7 +59,7 @@ class LogReader:
         wgs84_pose_fname: str = "wgs84.npz.lz4",
         map: Map = None,
         index_version: int = 0,
-        partitions: Set[PartitionEnum] = None,
+        partitions: Optional[Set[PartitionEnum]] = None,
     ):
         """Lightweight, low-level S3-aware utility for interacting with a specific log.
 
@@ -98,12 +97,12 @@ class LogReader:
             return np.full(n_sensor_measurements, True)
 
         # Fetch the indices from s3
-        dir = "s3://pit30m/partitions/"
-        fs = fsspec.filesystem(urlparse(dir).scheme, anon=True)
+        partitions_basepath = "s3://pit30m/partitions/"
+        fs = fsspec.filesystem(urlparse(partitions_basepath).scheme, anon=True)
 
         partition_indices = tuple()
         for partition in self.partitions:
-            partition_fpath = os.path.join(dir, partition.path_name, f"{self.log_id}.npz")
+            partition_fpath = os.path.join(partitions_basepath, partition.path_name, f"{self.log_id}.npz")
             if not fs.exists(partition_fpath):
                 raise ValueError(f"Partition file not found: {partition_fpath}")
 

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -46,6 +46,8 @@ VELODYNE_NAME = "hdl64e_12_middle_front_roof"
 UTM_ZONE_NUMBER = 17
 UTM_ZONE_LETTER = "N"
 
+PARTITIONS_BASEPATH = "s3://pit30m/partitions/"
+
 
 def gps_to_unix_timestamp(gps_seconds: float) -> float:
     return gps_seconds_to_utc(gps_seconds).timestamp()
@@ -106,12 +108,12 @@ class LogReader:
     @property
     def partition_assigments(self):
         """Fetches partition indices from S3 and converts them to boolean arrays according to the reader partition values"""
-        partitions_basepath = "s3://pit30m/partitions/"
-        fs = fsspec.filesystem(urlparse(partitions_basepath).scheme, anon=True)
+
+        fs = fsspec.filesystem(urlparse(PARTITIONS_BASEPATH).scheme, anon=True)
 
         partition_indices = tuple()
         for partition in self.partitions:
-            partition_fpath = os.path.join(partitions_basepath, partition.path_name, f"{self.log_id}.npz")
+            partition_fpath = os.path.join(PARTITIONS_BASEPATH, partition.path_name, f"{self.log_id}.npz")
             if not fs.exists(partition_fpath):
                 raise ValueError(f"Partition file not found: {partition_fpath}")
 

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property, lru_cache
-from typing import Iterator, Optional, Set, Union
+from typing import Any, Dict, Iterator, Optional, Set
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -14,12 +14,7 @@ import utm
 from PIL import Image
 
 from pit30m.camera import CamName
-from pit30m.data.partitions import (
-    GeoPartition,
-    PreProcessPartition,
-    QueryBasePartition,
-    SizePartition,
-)
+from pit30m.data.partitions import combine_partitions, fetch_partitions
 from pit30m.data.submap import Map
 from pit30m.time_utils import gps_seconds_to_utc
 
@@ -65,7 +60,7 @@ class LogReader:
         wgs84_pose_fname: str = "wgs84.npz.lz4",
         map: Map = None,
         index_version: int = 0,
-        partitions: Optional[Union[Set[Enum], Enum]] = {PreProcessPartition},
+        partitions: Optional[Dict[Enum, Any]] = None,
     ):
         """Lightweight, low-level S3-aware utility for interacting with a specific log.
 
@@ -82,6 +77,7 @@ class LogReader:
             map: Map object. If not provided, will try to load it from the log root
             index_version: Version of the index to use. Currently only 0 is supported.
             partitions: Set of partitions to load. These are used to load subset of the date (e.g., training queries).
+                defaults to None, which means that no sensor measurements are filtered.
         """
         self._log_root_uri = log_root_uri.rstrip("/")
         self._pose_fname = pose_fname
@@ -89,28 +85,26 @@ class LogReader:
         self._map = Map() if map is None else map
         # TODO(julieta) Semantic version this
         self._index_version = index_version
-
-        if partitions is None:
-            self.partitions = set()
-        else:
-            all_partitions = {
-                PreProcessPartition,
-                GeoPartition,
-                QueryBasePartition,
-                SizePartition,
-            }
-            assert partitions.issubset(
-                all_partitions
-            ), f"Invalid partitions: {partitions}"
-            self.partitions = partitions
-            # self.filtered_indices = self.compute_partition_filters()
+        self.partitions = partitions
 
     def __repr__(self) -> str:
         return f"Pit30M Log Reader: {self._log_root_uri}"
 
     @cached_property
-    def preprocess_partition(self):
-        return self.partitions[PreProcessPartition]
+    def partitions_index(self) -> np.ndarray:
+        """A boolean np array that accounts for the requested partitions. Currently defaults to Front Camera"""
+        if self.partitions is None:
+            n_sensor_measurements = len(self.get_cam_geo_index(CamName.MIDDLE_FRONT_WIDE.name))
+            return np.full(n_sensor_measurements, True)
+
+        # Fetch the indices from s3
+        partition_indices = fetch_partitions(self.log_id, self.partitions.keys())
+
+        # Combine the fetched indices with the values that the user requested
+        partition_indices_and_values = {}
+        for partition, partition_index in partition_indices.items():
+            partition_indices_and_values[partition] = (partition_index, self.partitions[partition])
+        return combine_partitions(partition_indices_and_values)
 
     @property
     def log_id(self) -> UUID:
@@ -139,9 +133,7 @@ class LogReader:
     @lru_cache(maxsize=4)
     def get_partition_assigments(self, partition="size"):
         """Returns a list of partition names for this log."""
-        index_fpath = os.path.join(
-            f"s3://pit30m/partitions/{partition}/{self.log_id}.npz"
-        )
+        index_fpath = os.path.join(f"s3://pit30m/partitions/{partition}/{self.log_id}.npz")
         if not self.fs.exists(index_fpath):
             raise ValueError(f"Partition file not found: {index_fpath}!")
 
@@ -155,9 +147,7 @@ class LogReader:
         WARNING: 'rel_path' entries in indexes may be padded with spaces on the right since they are fixed-width
         strings. If you need to use them directly, make sure you use `.strip()` to remove the spaces.
         """
-        index_fpath = os.path.join(
-            self.lidar_root, "index", f"index_v{self._index_version}.npz"
-        )
+        index_fpath = os.path.join(self.lidar_root, "index", f"index_v{self._index_version}.npz")
         if not self.fs.exists(index_fpath):
             raise ValueError(f"Index file not found: {index_fpath}!")
 
@@ -167,9 +157,7 @@ class LogReader:
     @lru_cache(maxsize=16)
     def get_cam_geo_index(self, cam_name: CamName) -> np.ndarray:
         """Returns a camera index of dtype CAM_INDEX_V0_0_DTYPE."""
-        index_fpath = os.path.join(
-            self.get_cam_root(cam_name), "index", f"index_v{self._index_version}.npz"
-        )
+        index_fpath = os.path.join(self.get_cam_root(cam_name), "index", f"index_v{self._index_version}.npz")
         if not self.fs.exists(index_fpath):
             raise ValueError(f"Index file not found: {index_fpath}!")
 
@@ -305,10 +293,7 @@ class LogReader:
         mrp = self.map_relative_poses_dense
         xyzs = np.stack((mrp["x"], mrp["y"], mrp["z"]), axis=1)
         # Handle submap IDs which were truncated upon encoded due to ending with a zero.
-        submaps = [
-            UUID(bytes=submap_uuid_bytes.ljust(16, b"\x00"))
-            for submap_uuid_bytes in mrp["submap_id"]
-        ]
+        submaps = [UUID(bytes=submap_uuid_bytes.ljust(16, b"\x00")) for submap_uuid_bytes in mrp["submap_id"]]
         return self._map.to_utm(xyzs, submaps)
 
     @cached_property
@@ -382,9 +367,7 @@ class LogReader:
                 shutter_time_s=index_entry["shutter_s"],
             )
 
-    def camera_iterator(
-        self, cam_name: CamName, start: int = 0, step: int = 1
-    ) -> Iterator[CameraImage]:
+    def camera_iterator(self, cam_name: CamName, start: int = 0, step: int = 1) -> Iterator[CameraImage]:
         assert start >= 0
         assert step > 0
         index = self.get_cam_geo_index(cam_name)

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -99,12 +99,8 @@ class LogReader:
 
         # Fetch the indices from s3
         partition_indices = fetch_partitions(self.log_id, self.partitions)
-
-        # Combine the fetched indices with the values that the user requested
-        partition_indices_and_values = {}
-        for partition, partition_index in partition_indices.items():
-            partition_indices_and_values[partition] = (partition_index, self.partitions[partition])
-        return combine_partitions(partition_indices_and_values)
+        combined_indices = np.logical_and.reduce(partition_indices)
+        return combined_indices
 
     @property
     def log_id(self) -> UUID:

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -90,7 +90,7 @@ class LogReader:
         return f"Pit30M Log Reader: {self._log_root_uri}"
 
     @cached_property
-    def partitions_index(self) -> np.ndarray:
+    def partitions_mask(self) -> np.ndarray:
         """
         Returns a boolean np array that accounts for the requested partitions, by setting sensor readings that should
         be skipped to False. Currently computed from the Front Camera.

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -13,7 +13,7 @@ import utm
 from PIL import Image
 
 from pit30m.camera import CamName
-from pit30m.data.partitions import PartitionEnum
+from pit30m.data.partitions import Partition
 from pit30m.data.submap import Map
 from pit30m.time_utils import gps_seconds_to_utc
 
@@ -61,7 +61,7 @@ class LogReader:
         wgs84_pose_fname: str = "wgs84.npz.lz4",
         map: Map = None,
         index_version: int = 0,
-        partitions: Optional[Set[PartitionEnum]] = None,
+        partitions: Optional[Set[Partition]] = None,
     ):
         """Lightweight, low-level S3-aware utility for interacting with a specific log.
 

--- a/pit30m/data/partitions.py
+++ b/pit30m/data/partitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -11,46 +12,57 @@ import fsspec
 import numpy as np
 
 
+class PartitionEnum(Enum):
+    @staticmethod
+    @abstractmethod
+    def value_to_index(val: PartitionEnum, index: np.ndarray) -> int:
+        ...
+
+
 # Preprocessing filters invalid poses and limits the number of poses per squared metre
-class PreProcessPartition(Enum):
+class PreProcessPartition(PartitionEnum):
     VALID = True
     INVALID = False
 
     @staticmethod
-    def value_to_index(val: PreProcessPartition.value, index: np.ndarray) -> int:
+    def value_to_index(val: PreProcessPartition, index: np.ndarray) -> int:
+        assert isinstance(val, PreProcessPartition), f"val must be a PreProcessPartition, not {type(val)=}"
         return index == val.value
 
 
 # Geographic partition into train/val/test
-class GeoPartition(Enum):
+class GeoPartition(PartitionEnum):
     TRAIN = 0
     VAL = 1
     TEST = 2
     # Some values migth be NaN, meaning they are outside the three geopartitions
 
     @staticmethod
-    def value_to_index(val: GeoPartition.value, index: np.ndarray) -> int:
+    def value_to_index(val: GeoPartition, index: np.ndarray) -> int:
+        assert isinstance(val, GeoPartition), f"val must be a GeoPartition, not {type(val)=}"
         return index == val.value
 
 
 # Query/base partitioning for retrieval/based localization
-class QueryBasePartition(Enum):
+class QueryBasePartition(PartitionEnum):
     QUERY = 0
     BASE = 1
 
     @staticmethod
-    def value_to_index(val: QueryBasePartition.value, index: np.ndarray) -> int:
+    def value_to_index(val: QueryBasePartition, index: np.ndarray) -> int:
+        assert isinstance(val, QueryBasePartition), f"val must be a QueryBasePartition, not {type(val)=}"
         return index == val.value
 
 
 # Size partitioning for mid/tiny/full
-class SizePartition(Enum):
+class SizePartition(PartitionEnum):
     TINY = 0
     MID = 1
     FULL = 2
 
     @staticmethod
-    def value_to_index(val: SizePartition.value, index: np.ndarray) -> int:
+    def value_to_index(val: SizePartition, index: np.ndarray) -> int:
+        assert isinstance(val, SizePartition), f"val must be a SizePartition, not {type(val)=}"
         if val == SizePartition.FULL:
             return np.full(len(index), True)
         elif val == SizePartition.MID:
@@ -59,7 +71,8 @@ class SizePartition(Enum):
             return index == val.value
 
 
-PARTITION_TO_NAME = {
+# path names on s3
+PARTITION_TO_PATH_NAME = {
     PreProcessPartition: "preprocessed",
     GeoPartition: "train_val_test",
     QueryBasePartition: "query_base",
@@ -69,8 +82,8 @@ PARTITION_TO_NAME = {
 
 def fetch_partitions(
     log_id: UUID,
-    partitions_to_fetch: Iterable[Union[PreProcessPartition, GeoPartition, QueryBasePartition, SizePartition]],
-) -> Dict[Union[PreProcessPartition, GeoPartition, QueryBasePartition, SizePartition], np.ndarray]:
+    partitions_to_fetch: Iterable[PartitionEnum],
+) -> Dict[PartitionEnum, np.ndarray]:
     """Fetch partitions from s3 for a given log"""
 
     dir = "s3://pit30m/partitions/"
@@ -78,7 +91,7 @@ def fetch_partitions(
 
     partitions = {}
     for partition in partitions_to_fetch:
-        partition_fpath = os.path.join(dir, PARTITION_TO_NAME[partition], f"{log_id}.npz")
+        partition_fpath = os.path.join(dir, PARTITION_TO_PATH_NAME[partition], f"{log_id}.npz")
         if not fs.exists(partition_fpath):
             raise ValueError(f"Partition file not found: {partition_fpath}")
 
@@ -88,11 +101,7 @@ def fetch_partitions(
     return partitions
 
 
-def combine_partitions(
-    partititons_dict: Dict[
-        Union[PreProcessPartition, GeoPartition, QueryBasePartition, SizePartition], Tuple[np.ndarray, Enum.value]
-    ]
-) -> np.ndarray:
+def combine_partitions(partititons_dict: Dict[PartitionEnum, Tuple[np.ndarray, PartitionEnum]]) -> np.ndarray:
     """Converts a bunch of partitions to a single boolean index that can be used for filtering in the logreader"""
 
     indices = []

--- a/pit30m/data/partitions.py
+++ b/pit30m/data/partitions.py
@@ -1,0 +1,63 @@
+import os
+from enum import Enum
+from typing import Dict, Iterable, Union
+from urllib.parse import urlparse
+from uuid import UUID
+
+import fsspec
+import numpy as np
+
+
+# Preprocessing filters invalid poses and limits the number of poses per squared metre
+class PreProcessPartition(Enum):
+    VALID = True
+    INVALID = False
+
+
+# Geograohic partition into train/val/test
+class GeoPartition(Enum):
+    TRAIN = 0
+    VAL = 1
+    TEST = 2
+
+
+# Query/base partitioning for retrieval/based localization
+class QueryBasePartition(Enum):
+    QUERY = 0
+    BASE = 1
+
+
+# Size partitioning for mid/tiny/full
+class SizePartition(Enum):
+    TINY = 0
+    MID = 1
+    FULL = 2
+
+
+PARTITION_TO_NAME = {
+    PreProcessPartition: "preprocessed",
+    GeoPartition: "train_val_test",
+    QueryBasePartition: "query_base",
+    SizePartition: "size",
+}
+
+
+def fetch_partitions(
+    log_id: UUID,
+    partitions_to_fetch: Iterable[Union[PreProcessPartition, GeoPartition, QueryBasePartition, SizePartition]],
+) -> Dict[Union[PreProcessPartition, GeoPartition, QueryBasePartition, SizePartition], np.ndarray]:
+    """Fetch partitions from s3 for a given log"""
+
+    dir = "s3://pit30m/partitions/"
+    fs = fsspec.filesystem(urlparse(dir).scheme, anon=True)
+
+    partitions = {}
+    for partition in partitions_to_fetch:
+        partition_fpath = os.path.join(dir, PARTITION_TO_NAME[partition], f"{log_id}.npz")
+        if not fs.exists(partition_fpath):
+            raise ValueError(f"Partition file not found: {partition_fpath}")
+
+        with fs.open(partition_fpath, "rb") as f:
+            partitions[partition] = np.load(f)["partition"]
+
+    return partitions

--- a/pit30m/data/partitions.py
+++ b/pit30m/data/partitions.py
@@ -88,39 +88,3 @@ class SizePartition(PartitionEnum):
     @property
     def path_name(self) -> str:
         return "size"
-
-
-# path names on s3
-def partition_to_path_name(partition: PartitionEnum) -> str:
-    if isinstance(partition, PreProcessPartition):
-        return "preprocessed"
-    elif isinstance(partition, GeoPartition):
-        return "train_val_test"
-    elif isinstance(partition, QueryBasePartition):
-        return "query_base"
-    elif isinstance(partition, SizePartition):
-        return "size"
-    else:
-        raise ValueError(f"Unknown partition: {partition}")
-
-
-def fetch_partitions(
-    log_id: UUID,
-    partitions_to_fetch: Iterable[PartitionEnum],
-) -> Tuple[np.ndarray]:
-    """Fetch partitions from s3 for a given log"""
-
-    dir = "s3://pit30m/partitions/"
-    fs = fsspec.filesystem(urlparse(dir).scheme, anon=True)
-
-    partitions = tuple()
-    for partition in partitions_to_fetch:
-        partition_fpath = os.path.join(dir, partition.path_name, f"{log_id}.npz")
-        if not fs.exists(partition_fpath):
-            raise ValueError(f"Partition file not found: {partition_fpath}")
-
-        with fs.open(partition_fpath, "rb") as f:
-            idx = np.load(f)["partition"]
-            partitions += (partition.value_to_index(partition, idx),)
-
-    return partitions

--- a/pit30m/data/partitions.py
+++ b/pit30m/data/partitions.py
@@ -6,10 +6,10 @@ from enum import Enum
 import numpy as np
 
 
-class PartitionEnum(Enum):
+class Partition(Enum):
     @staticmethod
     @abstractmethod
-    def value_to_index(val: PartitionEnum, index: np.ndarray) -> int:
+    def value_to_index(val: Partition, index: np.ndarray) -> int:
         ...
 
     @property
@@ -19,7 +19,7 @@ class PartitionEnum(Enum):
 
 
 # Preprocessing filters invalid poses and limits the number of poses per squared metre
-class PreProcessPartition(PartitionEnum):
+class PreProcessPartition(Partition):
     VALID = True
     INVALID = False
 
@@ -34,7 +34,7 @@ class PreProcessPartition(PartitionEnum):
 
 
 # Geographic partition into train/val/test
-class GeoPartition(PartitionEnum):
+class GeoPartition(Partition):
     TRAIN = 0
     VAL = 1
     TEST = 2
@@ -51,7 +51,7 @@ class GeoPartition(PartitionEnum):
 
 
 # Query/base partitioning for retrieval/based localization
-class QueryBasePartition(PartitionEnum):
+class QueryBasePartition(Partition):
     QUERY = 0
     BASE = 1
 
@@ -66,7 +66,7 @@ class QueryBasePartition(PartitionEnum):
 
 
 # Size partitioning for mid/tiny/full
-class SizePartition(PartitionEnum):
+class SizePartition(Partition):
     TINY = 0
     MID = 1
     FULL = 2

--- a/pit30m/data/partitions.py
+++ b/pit30m/data/partitions.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-import os
-from abc import ABC, abstractmethod, abstractproperty
+from abc import abstractmethod
 from enum import Enum
-from typing import Dict, Iterable, Set, Tuple
-from urllib.parse import urlparse
-from uuid import UUID
 
-import fsspec
 import numpy as np
 
 
@@ -17,7 +12,8 @@ class PartitionEnum(Enum):
     def value_to_index(val: PartitionEnum, index: np.ndarray) -> int:
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def path_name(self) -> str:
         ...
 
@@ -80,10 +76,12 @@ class SizePartition(PartitionEnum):
         assert isinstance(val, SizePartition), f"val must be a SizePartition, not {type(val)=}"
         if val == SizePartition.FULL:
             return np.full(len(index), True)
-        elif val == SizePartition.MID:
+        if val == SizePartition.MID:
             return np.logical_or(index == SizePartition.MID.value, index == SizePartition.FULL.value)
-        elif val == SizePartition.TINY:
+        if val == SizePartition.TINY:
             return index == val.value
+
+        raise ValueError(f"Invalid value for SizePartition: {val=}")
 
     @property
     def path_name(self) -> str:

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -22,14 +22,8 @@ def _real_log_reader(real_map: Map) -> LogReader:
     return LogReader("s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/", map=real_map)
 
 
-def test_real_log_read_index(real_log_reader: LogReader):
-    index = real_log_reader.get_cam_geo_index(CamName.PORT_REAR_WIDE)
-    assert len(index) > 1000
-    assert "webp" in index["rel_path"][42]
-
-
-@fixture(name="real_log_reader")
-def _real_log_reader_with_partitions() -> LogReader:
+@fixture(name="real_log_reader_with_partition")
+def _real_log_reader_with_partition() -> LogReader:
     # Creates a real log reader for a cool log with lots of snow
     return LogReader(
         "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
@@ -37,7 +31,29 @@ def _real_log_reader_with_partitions() -> LogReader:
     )
 
 
-def test_real_log_can_fetch_partition_index(real_log_reader: LogReader):
+@fixture(name="real_log_reader_with_partition")
+def _real_log_reader_with_two_partition() -> LogReader:
+    # Creates a real log reader for a cool log with lots of snow
+    return LogReader(
+        "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
+        partitions={PreProcessPartition: PreProcessPartition.VALID, GeoPartition: GeoPartition.TEST},
+    )
+
+
+def test_real_log_read_index(real_log_reader: LogReader):
+    index = real_log_reader.get_cam_geo_index(CamName.PORT_REAR_WIDE)
+    assert len(index) > 1000
+    assert "webp" in index["rel_path"][42]
+
+
+def test_real_log_can_fetch_partition_index(
+    real_log_reader: LogReader,
+    real_log_reader_with_partition: LogReader,
+):
+    """A log without arguments should filter out nothing"""
     index = real_log_reader.partitions_index
-    assert sum(index) > 100
+    assert sum(index) == len(index)
+
+    # If loading a partition, some measurements should be filtered outs
+    index = real_log_reader_with_partition.partitions_index
     assert sum(index) < len(index)

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -2,12 +2,7 @@ from pytest import fixture
 
 from pit30m.camera import CamName
 from pit30m.data.log_reader import LogReader
-from pit30m.data.partitions import (
-    GeoPartition,
-    PreProcessPartition,
-    QueryBasePartition,
-    SizePartition,
-)
+from pit30m.data.partitions import GeoPartition, PreProcessPartition, QueryBasePartition
 from pit30m.data.submap import DEFAULT_SUBMAP_INFO_PREFIX, Map
 
 

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -27,16 +27,16 @@ def _real_log_reader_with_partition() -> LogReader:
     # Creates a real log reader for a cool log with lots of snow
     return LogReader(
         "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
-        partitions={PreProcessPartition: PreProcessPartition.VALID},
+        partitions={PreProcessPartition.VALID},
     )
 
 
-@fixture(name="real_log_reader_with_partition")
+@fixture(name="real_log_reader_with_two_partitions")
 def _real_log_reader_with_two_partition() -> LogReader:
     # Creates a real log reader for a cool log with lots of snow
     return LogReader(
         "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
-        partitions={PreProcessPartition: PreProcessPartition.VALID, GeoPartition: GeoPartition.TEST},
+        partitions={PreProcessPartition.VALID, GeoPartition.TEST, QueryBasePartition.QUERY},
     )
 
 
@@ -49,11 +49,16 @@ def test_real_log_read_index(real_log_reader: LogReader):
 def test_real_log_can_fetch_partition_index(
     real_log_reader: LogReader,
     real_log_reader_with_partition: LogReader,
+    real_log_reader_with_two_partitions: LogReader,
 ):
     """A log without arguments should filter out nothing"""
     index = real_log_reader.partitions_index
     assert sum(index) == len(index)
 
-    # If loading a partition, some measurements should be filtered outs
+    # If loading a partition, some measurements should be filtered out
     index = real_log_reader_with_partition.partitions_index
     assert sum(index) < len(index)
+
+    # If loading more partitions, even fewer measurements should be available
+    smallest_index = real_log_reader_with_two_partitions.partitions_index
+    assert sum(smallest_index) < sum(index)

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -47,13 +47,13 @@ def test_real_log_can_fetch_partition_index(
     real_log_reader_with_two_partitions: LogReader,
 ):
     """A log without arguments should filter out nothing"""
-    index = real_log_reader.partitions_index
+    index = real_log_reader.partitions_mask
     assert sum(index) == len(index)
 
     # If loading a partition, some measurements should be filtered out
-    index = real_log_reader_with_partition.partitions_index
+    index = real_log_reader_with_partition.partitions_mask
     assert sum(index) < len(index)
 
     # If loading more partitions, even fewer measurements should be available
-    smallest_index = real_log_reader_with_two_partitions.partitions_index
+    smallest_index = real_log_reader_with_two_partitions.partitions_mask
     assert sum(smallest_index) < sum(index)

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -2,6 +2,12 @@ from pytest import fixture
 
 from pit30m.camera import CamName
 from pit30m.data.log_reader import LogReader
+from pit30m.data.partitions import (
+    GeoPartition,
+    PreProcessPartition,
+    QueryBasePartition,
+    SizePartition,
+)
 from pit30m.data.submap import DEFAULT_SUBMAP_INFO_PREFIX, Map
 
 
@@ -20,3 +26,18 @@ def test_real_log_read_index(real_log_reader: LogReader):
     index = real_log_reader.get_cam_geo_index(CamName.PORT_REAR_WIDE)
     assert len(index) > 1000
     assert "webp" in index["rel_path"][42]
+
+
+@fixture(name="real_log_reader")
+def _real_log_reader_with_partitions() -> LogReader:
+    # Creates a real log reader for a cool log with lots of snow
+    return LogReader(
+        "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
+        partitions={PreProcessPartition: PreProcessPartition.VALID},
+    )
+
+
+def test_real_log_can_fetch_partition_index(real_log_reader: LogReader):
+    index = real_log_reader.partitions_index
+    assert sum(index) > 100
+    assert sum(index) < len(index)

--- a/tests/data/partitions_test.py
+++ b/tests/data/partitions_test.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from pit30m.data.partitions import (
+    GeoPartition,
+    PreProcessPartition,
+    QueryBasePartition,
+    SizePartition,
+)
+
+
+def test_PreProcessPartition():
+    np.testing.assert_equal(
+        PreProcessPartition.value_to_index(PreProcessPartition.VALID, np.array([True, False])),
+        np.array([True, False]),
+    )
+
+    np.testing.assert_equal(
+        PreProcessPartition.value_to_index(PreProcessPartition.INVALID, np.array([True, False])),
+        np.array([False, True]),
+    )


### PR DESCRIPTION
Bundles partition into the dataloader. The dataloader may now receive an additional argument `partitions`, and provides a boolean array that indicates which sensor measurements (currently, from the front camera), should be skipped. If `partitions` is `None`, then no frames are skipped at all.

Closes #27