### PR TITLE
Support MRP arrays with small amounts of invalid submaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python CI Status](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml/badge.svg)](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
-![PyPI](https://img.shields.io/pypi/v/pit30m)
+[![PyPI](https://img.shields.io/pypi/v/pit30m)](https://pypi.org/project/pit30m/)
 [![Public on the AWS Open Data Registry](https://shields.io/badge/Open%20Data%20Registry-public-green?logo=amazonaws&style=flat)](#)
 
 ## Overview

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -54,8 +54,7 @@ UTM_ZONE_LETTER = "N"
 PARTITIONS_BASEPATH = "s3://pit30m/partitions/"
 
 # Original dtype for unified raw pose arrays. Regular users should be using specialized getters, such as those for
-# continuous or map-relative poses, not the raw poses. '?' entries are bool but numpy represents them at '?' for an
-# unknown reason.
+# continuous or map-relative poses, not the raw poses. '?' represents bool.
 RAW_POSE_DTYPE = np.dtype(
     [
         ("transmission_time", "<f8"),

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -371,12 +371,10 @@ class LogReader:
     def utm_poses_dense(self) -> Tuple[np.ndarray, np.ndarray]:
         """UTM poses for the log, ordered by time.
 
-        TODO(andrei): Update to provide altitude.
-
         Returns:
             A tuple with two elements:
-              - An n-long boolean array indicating whether the poses are valid
-              - An n-by-2 array with the UTM xy coordinates of the poses
+                - An n-long boolean array indicating whether the poses are valid
+                - An n-by-3 array with the UTM xy coordinates and altitudes of the poses
         """
         mrp = self.map_relative_poses_dense
         xyzs = rfn.structured_to_unstructured(mrp[["x", "y", "z"]])
@@ -385,11 +383,11 @@ class LogReader:
         submaps = [UUID(bytes=submap_uuid_bytes).ljust(16, b"\x00") for submap_uuid_bytes in mrp["submap_id"]]
 
         try:
-            xys = self._map.to_utm(xyzs, submaps)
+            xyzs = self._map.to_utm(xyzs, submaps)
         except SubmapPoseNotFoundException as e:
             raise RuntimeError(f"The pose of one of the submaps from log {self.log_id} was not found.") from e
 
-        return mrp["valid"], xys
+        return mrp["valid"], xyzs
 
     @cached_property
     def raw_wgs84_poses(self) -> np.ndarray:

--- a/pit30m/data/log_reader.py
+++ b/pit30m/data/log_reader.py
@@ -278,13 +278,8 @@ class LogReader:
 
         In practice, users should use the camera/LiDAR iterators instead.
         """
-        # XXX hack for development, do not land
-        # pose_fpath = os.path.join(self._log_root_uri, self._pose_fname)
-        root = self._log_root_uri.replace("s3://pit30m/", "/mnt/data/pit30m/pose-backup-2023-04-18/")
-        fs = fsspec.filesystem("file")
-        # fs = self.fs
-        pose_fpath = os.path.join(root, self._pose_fname)
-        with fs.open(pose_fpath, "rb") as in_compressed_f:
+        pose_fpath = os.path.join(self._log_root_uri, self._pose_fname)
+        with self.fs.open(pose_fpath, "rb") as in_compressed_f:
             with lz4.frame.open(in_compressed_f, "rb") as wgs84_f:
                 raw_poses = np.load(wgs84_f)["data"]
                 return raw_poses

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -30,10 +30,11 @@ LOG_ID_TO_MISSING_SUBMAPS = {
     # Found on 2023-02-20 -- 1a8132d0-2634-4ad0-e433-ce5987ef0120 submap UUID was missing
     "c9e9e7a7-f1cb-4af8-c5c9-3a610cbcc20e": [
         UUID("1a8132d0-2634-4ad0-e433-ce5987ef0120"),
-    ]
+    ],
 }
 
 KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids]
+
 
 class Singleton(type):
     _instances = {}
@@ -103,8 +104,9 @@ class Map(metaclass=Singleton):
             northing, while the altitude is the original altitude in the map.
         """
         assert len(map_poses_xyz) == len(submap_ids)
-        assert map_poses_xyz.ndim == 2 and map_poses_xyz.shape[1] == 3, \
-            f"Must pass N x 3 map pose array, got: {map_poses_xyz.shape}"
+        assert (
+            map_poses_xyz.ndim == 2 and map_poses_xyz.shape[1] == 3
+        ), f"Must pass N x 3 map pose array, got: {map_poses_xyz.shape}"
 
         off_utm = []
         for map_uuid in submap_ids:

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -35,7 +35,7 @@ LOG_ID_TO_MISSING_SUBMAPS = {
 BLANK_UUID = UUID("00000000-0000-0000-0000-000000000000")
 
 # test-query poses have been sanitized from the dataset and are not available. The sanitization includes the submap ID,
-# which for these entries has been replaced wiht th a null UUID.
+# which for these entries has been replaced with a null UUID.
 KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids] + [
     BLANK_UUID
 ]

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -1,7 +1,6 @@
 import os
 import pickle as pkl
 from typing import Iterable
-from urllib.parse import urlparse
 from uuid import UUID
 
 import numpy as np

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -31,14 +31,14 @@ LOG_ID_TO_MISSING_SUBMAPS = {
         UUID("1a8132d0-2634-4ad0-e433-ce5987ef0120"),
     ],
 }
+# Flattens (k -> [v]) to a flat list of all v's
+KNOWN_MISSING_SUBMAP_IDS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids]
 
 BLANK_UUID = UUID("00000000-0000-0000-0000-000000000000")
 
 # test-query poses have been sanitized from the dataset and are not available. The sanitization includes the submap ID,
 # which for these entries has been replaced with a null UUID.
-KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids] + [
-    BLANK_UUID
-]
+EXPECTED_INVALID_SUBMAPS = KNOWN_MISSING_SUBMAP_IDS + [BLANK_UUID]
 
 
 class Singleton(type):
@@ -120,7 +120,7 @@ class Map(metaclass=Singleton):
             try:
                 off_utm.append(self._submap_to_utm[map_uuid])
             except KeyError:
-                if not strict and map_uuid in KNOWN_MISSING_SUBMAPS:
+                if not strict and map_uuid in EXPECTED_INVALID_SUBMAPS:
                     off_utm.append([np.nan, np.nan])
                 else:
                     raise SubmapPoseNotFoundException(map_uuid) from KeyError

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -32,7 +32,13 @@ LOG_ID_TO_MISSING_SUBMAPS = {
     ],
 }
 
-KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids]
+BLANK_UUID = UUID("00000000-0000-0000-0000-000000000000")
+
+# test-query poses have been sanitized from the dataset and are not available. The sanitization includes the submap ID,
+# which for these entries has been replaced wiht th a null UUID.
+KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids] + [
+    BLANK_UUID
+]
 
 
 class Singleton(type):

--- a/pit30m/data/submap.py
+++ b/pit30m/data/submap.py
@@ -20,6 +20,21 @@ class SubmapPoseNotFoundException(Exception):
         super().__init__(f"Pose not found for submap {submap_id}")
 
 
+# These logs are known to contain at least one submap for which we do not have UTM.
+LOG_ID_TO_MISSING_SUBMAPS = {
+    # Crash on 2023-01-29 -- 5dedc51d-5bd3-4026-fd93-dabb4744ab23 submap UUID was missing
+    # Visual inspection seems to indicate this is in the city of pittsburgh, so not a highway.
+    "327b7948-4e5f-4d8c-f08b-4fc44a067996": [
+        UUID("5dedc51d-5bd3-4026-fd93-dabb4744ab23"),
+    ],
+    # Found on 2023-02-20 -- 1a8132d0-2634-4ad0-e433-ce5987ef0120 submap UUID was missing
+    "c9e9e7a7-f1cb-4af8-c5c9-3a610cbcc20e": [
+        UUID("1a8132d0-2634-4ad0-e433-ce5987ef0120"),
+    ]
+}
+
+KNOWN_MISSING_SUBMAPS = [submap_id for submap_ids in LOG_ID_TO_MISSING_SUBMAPS.values() for submap_id in submap_ids]
+
 class Singleton(type):
     _instances = {}
 
@@ -70,41 +85,61 @@ class Map(metaclass=Singleton):
         crs_wgs84 = CRS.from_epsg(WGS84_CODE)
         self._pit30m_utm_to_wgs84 = Transformer.from_crs(crs_utm, crs_wgs84)
 
-    def to_utm(self, map_poses_xyz: np.ndarray, submap_ids: Iterable[UUID]) -> np.ndarray:
-        """Returns corresponding UTM coordinates for the given pose + submap ID combinations. Assumes all poses are
-        within the same UTM zone, which holds for all of Pit30M.
-        TODO(andrei): We probably want altitude as well.
+    def to_utm(self, map_poses_xyz: np.ndarray, submap_ids: Iterable[UUID], strict: bool = True) -> np.ndarray:
+        """Returns corresponding UTM coordinates for the given pose + submap ID combinations.
+
+        Assumes all poses are within the same UTM zone, which holds for all of Pit30M.
 
         Args:
-            map_poses_xyz: n-by-3 array of map-relative poses (x, y, z).
-            submap_ids:   n-element array or list with each pose's submap ID.
+            map_poses_xyz:  n-by-3 array of map-relative poses (x, y, z).
+            submap_ids:     n-element array or list with each pose's submap ID.
+            strict:         If True, known-bad submap IDs will raise an exception. If False, they will be ignored and
+                            results will contain NaNs for those poses, leaving the caller to deal with them. Unexpected
+                            missing submaps, i.e., those NOT in 'LOG_ID_TO_MISSING_SUBMAPS' will still raise an
+                            exception.
+
         Returns:
-            An n-by-2 array of MRP poses transformed to UTM coordinates (x, y).
+            An n-by-3 array of MRP poses transformed to UTM coordinates (x, y, alt). x and y represent the easting and
+            northing, while the altitude is the original altitude in the map.
         """
         assert len(map_poses_xyz) == len(submap_ids)
+        assert map_poses_xyz.ndim == 2 and map_poses_xyz.shape[1] == 3, \
+            f"Must pass N x 3 map pose array, got: {map_poses_xyz.shape}"
 
         off_utm = []
         for map_uuid in submap_ids:
+            if not isinstance(map_uuid, UUID):
+                raise ValueError(f"Invalid submap ID type: {type(map_uuid)})")
             try:
                 off_utm.append(self._submap_to_utm[map_uuid])
-            except KeyError as e:
-                raise SubmapPoseNotFoundException(map_uuid) from KeyError
+            except KeyError:
+                if not strict and map_uuid in KNOWN_MISSING_SUBMAPS:
+                    off_utm.append([np.nan, np.nan])
+                else:
+                    raise SubmapPoseNotFoundException(map_uuid) from KeyError
 
         off_utm = np.array(off_utm)
-        return map_poses_xyz[:, :2] + off_utm
+        result = np.array(map_poses_xyz)
+        result[:, :2] += off_utm
+        # Make sure NaN rows are all NaNs
+        nan_mask = np.isnan(off_utm[:, 0])
+        result[nan_mask, :] = np.nan
 
-    def to_wgs84(self, map_poses, submap_ids):
-        """Converts map-relative poses to WGS84 (lat, lon) tuples.
+        return result
+
+    def to_wgs84(self, map_poses, submap_ids: Iterable[UUID], strict: bool = True) -> np.ndarray:
+        """Converts map-relative poses to WGS84 (lat, lon, alt) coordinates.
 
         Args:
-            map_poses:    N-dimensional array of map-relative poses ('x' and 'y' fields required).
-            submap_ids:   N-element array or list with each poses's submap ID.
+            map_poses:      N-dimensional array of map-relative poses ('x' and 'y' fields required).
+            submap_ids:     N-element array or list with each poses's submap ID.
+            strict:         Please see 'to_utm'.
 
         Returns:
-            An (N, 2) array of WGS84 (lat, lon).
+            An (N, 3) array of WGS84 (lat, lon, alt).
         """
-        utm_poses = self.to_utm(map_poses, submap_ids)
+        utm_poses = self.to_utm(map_poses, submap_ids, strict=strict)
         # 20x faster than manually looping over the coords in Python
         # pylint: disable=unpacking-non-sequence
         wgs_lat, wgs_lon = self._pit30m_utm_to_wgs84.transform(utm_poses[:, 0, np.newaxis], utm_poses[:, 1, np.newaxis])
-        return np.hstack((wgs_lat, wgs_lon))
+        return np.hstack((wgs_lat, wgs_lon, utm_poses[:, 2, np.newaxis]))

--- a/pit30m/indexing.py
+++ b/pit30m/indexing.py
@@ -1,5 +1,6 @@
 """Utility functions for timing, data association, and indexing."""
 
+import math
 import multiprocessing as mp
 import os
 from urllib.parse import urlparse
@@ -314,6 +315,7 @@ def build_camera_index(in_root, log_reader, cam_dir, _logger):
         if delta_mrp_s > 0.10:
             mrp = None
             mrp_present = False
+            utm_present = False
             mrp_valid = False
             mrp_time_s, mrp_x, mrp_y, mrp_z, mrp_roll, mrp_pitch, mrp_yaw = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
             mrp_submap_id = b"\x00" * 16
@@ -323,10 +325,14 @@ def build_camera_index(in_root, log_reader, cam_dir, _logger):
             mrp = mrp_poses[pose_idx, ...].tolist()
             utm = utm_poses[pose_idx, ...].tolist()
             mrp_present = True
+            utm_present = True
             mrp_time_s, mrp_valid, mrp_submap_id, mrp_x, mrp_y, mrp_z, mrp_roll, mrp_pitch, mrp_yaw = mrp
-            utm_x, utm_y = utm
-            # TODO(andrei): Update me
-            utm_z = 0
+            utm_x, utm_y, utm_z = utm
+            if math.isnan(utm_x):
+                utm_x = 0.0
+                utm_y = 0.0
+                utm_z = 0.0
+                utm_present = False
 
             # Handle submap IDs which were truncated upon encoded due to ending with a zero.
             mrp_submap_id = mrp_submap_id.ljust(16, b"\x00")
@@ -372,9 +378,8 @@ def build_camera_index(in_root, log_reader, cam_dir, _logger):
                 mrp_roll,
                 mrp_pitch,
                 mrp_yaw,
-                # No MRP === No UTM
-                mrp_present,
-                mrp_present,
+                utm_present,
+                utm_present,
                 utm_x,
                 utm_y,
                 utm_z,
@@ -513,6 +518,7 @@ def build_lidar_index(in_root, log_reader, lidar_dir, _logger):
             mrp = None
             mrp_present = False
             mrp_valid = False
+            utm_present = False
             mrp_time_s, mrp_x, mrp_y, mrp_z, mrp_roll, mrp_pitch, mrp_yaw = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
             mrp_submap_id = b"\x00" * 16
             utm = None
@@ -521,10 +527,14 @@ def build_lidar_index(in_root, log_reader, lidar_dir, _logger):
             mrp = mrp_poses[pose_idx, ...].tolist()
             utm = utm_poses[pose_idx, ...].tolist()
             mrp_present = True
+            utm_present = True
             mrp_time_s, mrp_valid, mrp_submap_id, mrp_x, mrp_y, mrp_z, mrp_roll, mrp_pitch, mrp_yaw = mrp
-            utm_x, utm_y = utm
-            # TODO(andrei): Update me
-            utm_z = 0
+            utm_x, utm_y, utm_z = utm
+            if math.isnan(utm_x):
+                utm_x = 0.0
+                utm_y = 0.0
+                utm_z = 0.0
+                utm_present = False
 
             # Handle submap IDs which were truncated upon encoded due to ending with a zero.
             mrp_submap_id = mrp_submap_id.ljust(16, b"\x00")
@@ -572,9 +582,9 @@ def build_lidar_index(in_root, log_reader, lidar_dir, _logger):
                 mrp_roll,
                 mrp_pitch,
                 mrp_yaw,
-                # No MRP === No UTM
-                mrp_present,
-                mrp_present,
+                # No MRP => No UTM
+                utm_present,
+                utm_present,
                 utm_x,
                 utm_y,
                 utm_z,

--- a/pit30m/monkeywrench.py
+++ b/pit30m/monkeywrench.py
@@ -237,13 +237,12 @@ class MonkeyWrench:
                                 check its shape, load the metadata and ensure it's not corrupted, load the LiDAR and
                                 check its shape too, etc.
         """
-        # XXX(andrei): This function is deprecated.
         self.index_all_cameras(log_id=log_id, out_index_fpath=out_index_fpath, check=check)
         self.index_lidar(log_id=log_id, out_index_fpath=out_index_fpath, check=check)
         res = self.diagnose_misc(log_id=log_id, out_index_fpath=out_index_fpath, check=check)
-        # XXX(andrei): Turn the misc diagnosis into a mini report too.
-        if len(res) > 0:
-            print("WARNING: misc non-sensor data had errors. See above for more information.")
+        # # TODO(andrei): Turn the misc diagnosis into a mini report too.
+        # if len(res) > 0:
+        #     print("WARNING: misc non-sensor data had errors. See above for more information.")
 
         print("Log indexing complete.")
 
@@ -257,10 +256,6 @@ class MonkeyWrench:
 
     def get_cam_dir(self, log_root: str, cam_name: str) -> str:
         return os.path.join(log_root, "cameras", cam_name.lstrip("/"))
-
-    # def next_to_validate(self, max: int = 10):
-    #     """Next logs to validate."""
-    #     pass
 
     def stat(self, max: int = 100, quiet: bool = False):
         all_logs = self.all_logs[:max]
@@ -1126,7 +1121,7 @@ class MonkeyWrench:
         else:
             errors.append(("vehicle_state", "missing"))
 
-        # XXX(andrei): Write this as a report entry! Discriminate between WARNING and ERROR. The difference is about
+        # TODO(andrei): Write this as a report entry! Discriminate between WARNING and ERROR. The difference is about
         # which files are missing. E.g., tl states missing is a warning, but core metadata, poses, or calibration
         # missing is an error.
         if check and len(errors) > 0:

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -21,8 +21,10 @@ def _real_log_reader(real_map: Map) -> LogReader:
 @fixture(name="real_log_reader_with_test_partition")
 def _real_log_reader_test_query(real_map: Map) -> LogReader:
     # Creates a real log reader for a cool log with lots of snow
-    return LogReader("s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
-                     partitions={GeoPartition.TEST,  QueryBasePartition.QUERY})
+    return LogReader(
+        "s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/", partitions={GeoPartition.TEST, QueryBasePartition.QUERY}
+    )
+
 
 @fixture(name="real_log_reader_with_partition")
 def _real_log_reader_with_partition() -> LogReader:

--- a/tests/data/log_reader_integration_test.py
+++ b/tests/data/log_reader_integration_test.py
@@ -18,6 +18,12 @@ def _real_log_reader(real_map: Map) -> LogReader:
     return LogReader("s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/", map=real_map)
 
 
+@fixture(name="real_log_reader_with_test_partition")
+def _real_log_reader_test_query(real_map: Map) -> LogReader:
+    # Creates a real log reader for a cool log with lots of snow
+    return LogReader("s3://pit30m/7e9b5978-0a52-401c-dcd1-65c8d9930ad8/",
+                     partitions={GeoPartition.TEST,  QueryBasePartition.QUERY})
+
 @fixture(name="real_log_reader_with_partition")
 def _real_log_reader_with_partition() -> LogReader:
     # Creates a real log reader for a cool log with lots of snow
@@ -44,6 +50,16 @@ def test_real_log_can_fetch_raw_pose_data(real_log_reader: LogReader):
 def test_real_log_can_fetch_raw_wgs84_poses(real_log_reader: LogReader):
     poses = real_log_reader.raw_wgs84_poses
     assert len(poses) > 0
+
+
+def test_real_log_with_test_partition_can_fetch_dense_utm(
+    real_log_reader_with_test_partition: LogReader,
+):
+    mask, poses = real_log_reader_with_test_partition.utm_poses_dense
+    assert np.sum(~np.isnan(poses)) > 0
+    assert len(poses) > 1000, "Expected to have a reasonable number of UTM poses."
+    assert len(poses) == len(mask)
+    assert len(poses) == np.sum(~np.isnan(mask)), "All UTMs must be invalid on a log reading test query data!"
 
 
 def test_lidar_index_is_sorted(real_log_reader: LogReader):

--- a/tests/submap_test.py
+++ b/tests/submap_test.py
@@ -43,9 +43,9 @@ def test_utm():
         utm_coords,
         np.array(
             [
-                [7, 7,0],
-                [11, 11,0],
-                [18, 20.3,16],
+                [7, 7, 0],
+                [11, 11, 0],
+                [18, 20.3, 16],
             ]
         ),
     )
@@ -75,17 +75,18 @@ def test_missing_submap_utm():
 
     for log_id in LOG_ID_TO_MISSING_SUBMAPS.keys():
         lr = LogReader(log_root_uri=f"s3://pit30m/{log_id}/")
-        sids = []
-        sids = [UUID(bytes=submap_uuid_bytes.ljust(16, b"\x00"))
-                for submap_uuid_bytes in lr.map_relative_poses_dense["submap_id"]]
-        # for submap_uuid_bytes in lr.map_relative_poses_dense["submap_id"]:
-        #     submap_uuid_bytes = submap_uuid_bytes.ljust(16, b"\x00")
-        #     sids.append(UUID(bytes=submap_uuid_bytes))
-
-        mrp_xyz = np.stack((lr.map_relative_poses_dense["x"],
-                         lr.map_relative_poses_dense["y"],
-                         lr.map_relative_poses_dense["z"],
-                         ), axis=1)
+        sids = [
+            UUID(bytes=submap_uuid_bytes.ljust(16, b"\x00"))
+            for submap_uuid_bytes in lr.map_relative_poses_dense["submap_id"]
+        ]
+        mrp_xyz = np.stack(
+            (
+                lr.map_relative_poses_dense["x"],
+                lr.map_relative_poses_dense["y"],
+                lr.map_relative_poses_dense["z"],
+            ),
+            axis=1,
+        )
         with pytest.raises(SubmapPoseNotFoundException):
             utm_poses = map_.to_utm(mrp_xyz, sids)
         with pytest.raises(SubmapPoseNotFoundException):
@@ -93,7 +94,6 @@ def test_missing_submap_utm():
 
         # Completely unexpected submap IDs should always raise
         mutated_sids = list(sids)
-        print(len(sids), len(mutated_sids))
         mutated_sids[0] = completely_unexpected_submap_uuid
         with pytest.raises(SubmapPoseNotFoundException):
             utm_poses = map_.to_utm(mrp_xyz, mutated_sids, strict=True)
@@ -103,6 +103,4 @@ def test_missing_submap_utm():
         # Finally, make sure we get sensible NaN rows in the non-strict case
         utm_poses = map_.to_utm(mrp_xyz, sids, strict=False)
         assert np.isnan(utm_poses.ravel()).sum() > 0
-        assert np.isnan(utm_poses.ravel()).sum() % 3 == 0   # A row is either all NaN or all non-NaN
-
-
+        assert np.isnan(utm_poses.ravel()).sum() % 3 == 0  # A row is either all NaN or all non-NaN

--- a/tests/submap_test.py
+++ b/tests/submap_test.py
@@ -71,24 +71,27 @@ def test_anonymized_entry():
     """Ensure that handling an entry with a null submap ID yields empty UTMs."""
     blank_uuid = UUID("00000000-0000-0000-0000-000000000000")
     map_ = Map()
-    mrp_xyz_zeros = np.array([
-        [0.0, 0.0, 0.0]
-    ])
+    mrp_xyz_zeros = np.array([[0.0, 0.0, 0.0]])
     utm_poses = map_.to_utm(mrp_xyz_zeros, [blank_uuid], strict=False)
     assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
 
-    mrp_xyz_nonzeros = np.array([
-        [1.0, 1.0, 1.0],
-        [2.0, 2.0, 2.0],
-    ])
+    mrp_xyz_nonzeros = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0],
+        ]
+    )
     utm_poses = map_.to_utm(mrp_xyz_nonzeros, [blank_uuid, blank_uuid], strict=False)
     assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan], [np.nan, np.nan, np.nan]]), equal_nan=True)
 
-    mrp_xyz_nans = np.array([
-        [np.nan, np.nan, np.nan],
-    ])
+    mrp_xyz_nans = np.array(
+        [
+            [np.nan, np.nan, np.nan],
+        ]
+    )
     utm_poses = map_.to_utm(mrp_xyz_nans, [blank_uuid], strict=False)
     assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
+
 
 def test_missing_submap_utm():
     """Integration test for handling the very few submaps with no UTM coordinates."""

--- a/tests/submap_test.py
+++ b/tests/submap_test.py
@@ -2,8 +2,14 @@ import uuid
 from uuid import UUID
 
 import numpy as np
+import pytest
 
-from pit30m.data.submap import Map
+from pit30m.data.log_reader import LogReader
+from pit30m.data.submap import (
+    LOG_ID_TO_MISSING_SUBMAPS,
+    Map,
+    SubmapPoseNotFoundException,
+)
 
 
 def test_singleton():
@@ -26,9 +32,9 @@ def test_utm():
 
     fake_poses = np.array(
         [
-            [7, 7],
-            [1, 1],
-            [-2, 0.3],
+            [7, 7, 0],
+            [1, 1, 0],
+            [-2, 0.3, 16],
         ]
     )
 
@@ -37,9 +43,9 @@ def test_utm():
         utm_coords,
         np.array(
             [
-                [7, 7],
-                [11, 11],
-                [18, 20.3],
+                [7, 7,0],
+                [11, 11,0],
+                [18, 20.3,16],
             ]
         ),
     )
@@ -50,7 +56,7 @@ def test_wgs84():
 
     fake_poses = np.array(
         [
-            [0.33, -0.33],
+            [0.33, -0.33, 0.0],
         ]
     )
     fake_submap_ids = [uuid.uuid3(uuid.NAMESPACE_URL, "pratt")]
@@ -58,4 +64,34 @@ def test_wgs84():
 
     wgs84_coords = map.to_wgs84(fake_poses, fake_submap_ids)
     # GT computed using epsg.io
-    np.testing.assert_allclose(wgs84_coords, np.array([[43.531002, -79.3625012]]))
+    np.testing.assert_allclose(wgs84_coords, np.array([[43.531002, -79.3625012, 0.0]]))
+
+
+def test_missing_submap_utm():
+    """Integration test for handling the very few submaps with no UTM coordinates."""
+    map_ = Map()
+
+    for log_id in LOG_ID_TO_MISSING_SUBMAPS.keys():
+        lr = LogReader(log_root_uri=f"s3://pit30m/{log_id}/")
+        sids = []
+        # sids = [UUID(bytes=submap_uuid_bytes) for submap_uuid_bytes in lr.map_relative_poses_dense["submap_id"]]
+        for submap_uuid_bytes in lr.map_relative_poses_dense["submap_id"]:
+            submap_uuid_bytes = submap_uuid_bytes.ljust(16, b"\x00")
+            sids.append(UUID(bytes=submap_uuid_bytes))
+
+        mrp_xyz = np.hstack((lr.map_relative_poses_dense["x"][:, np.newaxis],
+                         lr.map_relative_poses_dense["y"][:, np.newaxis],
+                         lr.map_relative_poses_dense["z"][:, np.newaxis],
+                         ))
+        with pytest.raises(SubmapPoseNotFoundException):
+            utm_poses = map_.to_utm(mrp_xyz, sids)
+            assert np.isnan(utm_poses.ravel()).sum() == 0
+        with pytest.raises(SubmapPoseNotFoundException):
+            utm_poses = map_.to_utm(mrp_xyz, sids, strict=True)
+            assert np.isnan(utm_poses.ravel()).sum() == 0
+
+        utm_poses = map_.to_utm(mrp_xyz, sids, strict=False)
+        assert np.isnan(utm_poses.ravel()).sum() > 0
+        assert np.isnan(utm_poses.ravel()).sum() % 3 == 0   # A row is either all NaN or all non-NaN
+
+

--- a/tests/submap_test.py
+++ b/tests/submap_test.py
@@ -67,6 +67,29 @@ def test_wgs84():
     np.testing.assert_allclose(wgs84_coords, np.array([[43.531002, -79.3625012, 0.0]]))
 
 
+def test_anonymized_entry():
+    """Ensure that handling an entry with a null submap ID yields empty UTMs."""
+    blank_uuid = UUID("00000000-0000-0000-0000-000000000000")
+    map_ = Map()
+    mrp_xyz_zeros = np.array([
+        [0.0, 0.0, 0.0]
+    ])
+    utm_poses = map_.to_utm(mrp_xyz_zeros, [blank_uuid], strict=False)
+    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
+
+    mrp_xyz_nonzeros = np.array([
+        [1.0, 1.0, 1.0],
+        [2.0, 2.0, 2.0],
+    ])
+    utm_poses = map_.to_utm(mrp_xyz_nonzeros, [blank_uuid, blank_uuid], strict=False)
+    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan], [np.nan, np.nan, np.nan]]), equal_nan=True)
+
+    mrp_xyz_nans = np.array([
+        [np.nan, np.nan, np.nan],
+    ])
+    utm_poses = map_.to_utm(mrp_xyz_nans, [blank_uuid], strict=False)
+    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
+
 def test_missing_submap_utm():
     """Integration test for handling the very few submaps with no UTM coordinates."""
     map_ = Map()

--- a/tests/submap_test.py
+++ b/tests/submap_test.py
@@ -75,20 +75,20 @@ def test_anonymized_entry():
         [0.0, 0.0, 0.0]
     ])
     utm_poses = map_.to_utm(mrp_xyz_zeros, [blank_uuid], strict=False)
-    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
+    assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
 
     mrp_xyz_nonzeros = np.array([
         [1.0, 1.0, 1.0],
         [2.0, 2.0, 2.0],
     ])
     utm_poses = map_.to_utm(mrp_xyz_nonzeros, [blank_uuid, blank_uuid], strict=False)
-    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan], [np.nan, np.nan, np.nan]]), equal_nan=True)
+    assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan], [np.nan, np.nan, np.nan]]), equal_nan=True)
 
     mrp_xyz_nans = np.array([
         [np.nan, np.nan, np.nan],
     ])
     utm_poses = map_.to_utm(mrp_xyz_nans, [blank_uuid], strict=False)
-    assert np.allclose(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
+    assert np.array_equal(utm_poses, np.array([[np.nan, np.nan, np.nan]]), equal_nan=True)
 
 def test_missing_submap_utm():
     """Integration test for handling the very few submaps with no UTM coordinates."""


### PR DESCRIPTION
Invalid submaps are the two submaps for which we do not have submap UTMs. They affect very little data but we want to still index the underlying logs, and just leave gaps in UTM-ified MRP wherever the submap UTM is unavailable.

Also adds altitude to UTM methods for convenience (just the MRP altitude passed through). Worth noting that the MRP altitude roughly but not exactly corresponds to altitude above sea level.

Solves #44.