### PR TITLE
Make ci button report build on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Python CI
 
 on: 
-  pull_request
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: Python CI
 
-on: [pull_request, push]
+on: 
+  pull_request
+  push:
+    branches:
+      - main
 
 env:
   POETRY_VERSION: 1.3.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Python CI
 
-on: [pull_request]
+on: [pull_request, push]
 
 env:
   POETRY_VERSION: 1.3.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pit30M Development Kit
 
-[![Python CI Status](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml/badge.svg)](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml)
+[![Python CI Status](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/pit30m/pit30m/actions/workflows/ci.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/pit30m)](https://pypi.org/project/pit30m/)
 [![Public on the AWS Open Data Registry](https://shields.io/badge/Open%20Data%20Registry-public-green?logo=amazonaws&style=flat)](#)


### PR DESCRIPTION
Right now it is reporting the latest build from any branch, so it is broken often, even if `main` is not.